### PR TITLE
Rename logger for SCP Word Extractor for clarity and consistency

### DIFF
--- a/data_manager.py
+++ b/data_manager.py
@@ -6,7 +6,7 @@ import logging
 import re
 from constants import DICTIONARY_DIR, THESAURUS_DIR
 
-logger = logging.getLogger("scp_extractor")
+logger = logging.getLogger("scp_word_extractor")
 
 
 def ensure_data_directories():

--- a/log_config.py
+++ b/log_config.py
@@ -24,7 +24,7 @@ def setup_logging():
     )
 
     # Create logger
-    logger = logging.getLogger("scp_extractor")
+    logger = logging.getLogger("scp_word_extractor")
     logger.info("Logging initialized")
 
     return logger

--- a/word_extractor.py
+++ b/word_extractor.py
@@ -4,7 +4,7 @@ import re
 import logging
 from constants import MIN_WORD_LENGTH
 
-logger = logging.getLogger("scp_extractor")
+logger = logging.getLogger("scp_word_extractor")
 
 
 def extract_unique_words_from_wikidot(content):


### PR DESCRIPTION
Update the logger name from "scp_extractor" to "scp_word_extractor" across relevant files to improve clarity and maintain consistency in logging.